### PR TITLE
Force Py3.12 when creating venv for both inbox and broadcast APIs

### DIFF
--- a/broadcast/run.sh
+++ b/broadcast/run.sh
@@ -3,7 +3,7 @@ set -e
 
 if [ ! -d ".venv" ]; then
     echo "Virtual environment not found. Creating one..."
-    uv venv .venv
+    uv venv -p 3.12 .venv
     echo "Virtual environment created successfully."
 else
     echo "Virtual environment already exists."

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@ set -e
 
 if [ ! -d ".venv" ]; then
     echo "Virtual environment not found. Creating one..."
-    uv venv .venv
+    uv venv -p 3.12 .venv
     echo "Virtual environment created successfully."
 else
     echo "Virtual environment already exists."


### PR DESCRIPTION
This PR adds the constraints to `run.sh` files of `inbox` and `broadcast` APIs to use Python 3.12. 

Scenario: I have 3.13 Python installed (therefore that's the latest version `uv` is using) and venv can't resolve as `py_fast_rsync` is currently not available for Py3.13.
